### PR TITLE
Bump alpine from 3.19 to 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 RUN go build .
 
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --update-cache --no-cache \
         ca-certificates


### PR DESCRIPTION
Bumps alpine from 3.19 to 3.20.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-minor ...